### PR TITLE
Add environment file patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,12 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Environment files
+.env
+.env.local
+.env.development
+.env.test
+.env.production
+.env.staging
+*.env


### PR DESCRIPTION
- Added .env and related environment file patterns to ignore sensitive configuration files
- Includes .env.local, .env.development, .env.test, .env.production, .env.staging
- Added *.env pattern to catch any environment files with .env extension
- Prevents accidental commit of API keys and sensitive configuration data